### PR TITLE
Template Path fallback and exception handling

### DIFF
--- a/inertia_flask/responses.py
+++ b/inertia_flask/responses.py
@@ -165,6 +165,11 @@ class BaseInertiaResponseMixin:
         template_path = current_app.config.get(
             f"{str(blueprint).upper() + '_' if blueprint is not None else ''}INERTIA_TEMPLATE"
         )
+        if template_path is None:
+            template_path = current_app.config.get("INERTIA_TEMPLATE")
+            current_app.logger.warning(
+                f"Blueprint template not found for {blueprint}. Using global template."
+            )
         try:
             current_app.jinja_env.get_template(template_path)
         except TemplateNotFound:
@@ -172,6 +177,11 @@ class BaseInertiaResponseMixin:
             current_app.logger.warning(
                 f"Blueprint template not found: {template_path}. Using global template."
             )
+        except Exception as e:
+            current_app.logger.error(
+                f"Error loading template: {template_path}. Error: {e}"
+            )
+            raise
         return render_template(
             template_path,
             page=data,


### PR DESCRIPTION
Added a null check for template path before passing it to Jinja2. Previously, when a blueprint-specific template wasn't configured, the code would try to use None as a template path, causing an AttributeError `AttributeError: 'NoneType' object has no attribute 'split'` Now we properly fall back to the global template.

Stack trace I saw in my local dev:

```
Traceback (most recent call last):
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/inertia-flask/inertia_flask/responses.py", line 246, in decorated_function
    return InertiaResponse(request, component, props)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/inertia-flask/inertia_flask/responses.py", line 223, in __init__
    content = self.build_first_load(data, request.blueprint or None)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/inertia-flask/inertia_flask/responses.py", line 175, in build_first_load
    current_app.jinja_env.get_template(template_path)
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/jinja2/environment.py", line 1016, in get_template
    return self._load_template(name, globals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/jinja2/environment.py", line 975, in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/jinja2/loaders.py", line 126, in load
    source, filename, uptodate = self.get_source(environment, name)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/templating.py", line 65, in get_source
    return self._get_source_fast(environment, template)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/flask/templating.py", line 96, in _get_source_fast
    return loader.get_source(environment, template)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/jinja2/loaders.py", line 197, in get_source
    pieces = split_template_path(template)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/code/liveset-indexer/.venv/lib/python3.12/site-packages/jinja2/loaders.py", line 30, in split_template_path
    for piece in template.split("/"):
                 ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```